### PR TITLE
fix: only use breadcrumbs if more than one section

### DIFF
--- a/src/dinghy/templates/digest.html.j2
+++ b/src/dinghy/templates/digest.html.j2
@@ -45,6 +45,12 @@
     line-height: 1.3;
     color: black;
   }
+  .navslugs {
+    margin-top: -1em;
+  }
+  .totop {
+    float: right;
+  }
   ul {
     padding-left: 0;
     list-style-type: none;
@@ -198,9 +204,15 @@
 <body id="top">
 
 <h1>{{ page_title() }}</h1>
-{% for container in results -%}
-  <a href="#{{ container.title | slugify }}">{{ container.title | trim }}</a>{% if not loop.last -%}&nbsp;|&nbsp;{%- endif -%}
-{% endfor -%}
+
+{% if results|length > 1 %}
+  <p class="navslugs">»
+    {% for container in results -%}
+      <a href="#{{ container.title | slugify }}">{{ container.title | trim }}</a>
+      {%- if not loop.last -%}&nbsp;|&nbsp;{%- endif -%}
+    {% endfor -%}
+  </p>
+{% endif %}
 
 <ul class="repos">
   {% for container in results -%}
@@ -209,7 +221,9 @@
         {{- container.title|trim -}}
       </a></span>
       {{ container.container_kind }} {{ container.kind }}
-      <a style="float: right" href="#top">[back to top]</a>
+      {% if results|length > 1 %}
+        <a class="totop" href="#top">[back to top]</a>
+      {% endif %}
       </p>
       {% if container.entries %}
         <ul class="entries">


### PR DESCRIPTION
I like what you've done, thanks.  This makes the breadcrumbs only appear if there are multiple sections, and tweaks the styling just a bit.